### PR TITLE
fix: should allow undefined `options`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function titleCase(str, options) {
   if (!str) return ''
 
   const stop = opts.stopwords || defaults
-  const keep = options.keepSpaces
+  const keep = opts.keepSpaces
   const splitter = /(\s+|[-‑–—])/
 
   return str

--- a/test.js
+++ b/test.js
@@ -35,3 +35,15 @@ test('titleCase', function(t) {
   })
   t.end()
 })
+
+test('allow undefined `options`', function(t) {
+  const patterns = [
+    ['this is a test', 'This Is a Test'],
+    ['Thing With     Extra Spaces', 'Thing With Extra Spaces']
+  ]
+
+  patterns.forEach(pattern => {
+    t.equal(titleCase(pattern[0]), pattern[1], pattern[1])
+  })
+  t.end()
+})


### PR DESCRIPTION
this fixes https://github.com/words/ap-style-title-case/issues/5