### PR TITLE
Add '/' to the list of splitter characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ export function apStyleTitleCase(value, options) {
 
   const stop = configuration.stopwords || defaults
   const keep = configuration.keepSpaces
-  const splitter = /(\s+|[-‑–—,:;!?()])/
+  const splitter = /(\s+|[-‑–—,:;!?()\/])/
 
   return value
     .split(splitter)

--- a/test.js
+++ b/test.js
@@ -44,7 +44,8 @@ test('ap-style-title-case', function () {
       'Observations of isolated pulsars and disk-fed X-ray binaries.',
       'Observations of Isolated Pulsars and Disk-Fed X-Ray Binaries.'
     ],
-    ['Shakspeare; Or, the Poet', 'Shakspeare; or, the Poet']
+    ['Shakspeare; Or, the Poet', 'Shakspeare; or, the Poet'],
+    ['before/after and/or end', 'Before/After and/or End']
   ]
 
   for (const pattern of patterns) {


### PR DESCRIPTION
Capitalize the word right after a `/` character.

Input: `before/after and/or end`
Expected output: `Before/After and/or End`
Current output: `Before/after And/or End`
